### PR TITLE
Fix/001 -  fix Code Insertion in Commit Message for "StartingWithCode" Template

### DIFF
--- a/Ghost.Application/Commands/CommitCommand.cs
+++ b/Ghost.Application/Commands/CommitCommand.cs
@@ -1,15 +1,11 @@
 ﻿using Cocona;
 using Figgle;
 using Ghost.Application.Filters;
-using Ghost.Application.UseCases.EditMessage;
 using Ghost.Application.UseCases.PickMessage;
-using Ghost.Application.UseCases.ReviewMessage;
 using Ghost.Common.Services;
 using Ghost.Infrastructure.Models.Enum;
 using Ghost.Infrastructure.Services;
 using MediatR;
-using Microsoft.Extensions.Options;
-using System.Text;
 
 namespace Ghost.Infrastructure.Commands;
 

--- a/Ghost.Common/Factories/IPromptFactory.cs
+++ b/Ghost.Common/Factories/IPromptFactory.cs
@@ -1,8 +1,8 @@
-﻿namespace Ghost.Infrastructure.Factories;
+﻿using Ghost.Infrastructure.Models.Enum;
+
+namespace Ghost.Infrastructure.Factories;
 
 public interface IPromptFactory
 {
-    string CreateCommitStartingWithCodePrompt(string gitdiff, string code);
-    string CreateConventionalCommitPrompt(string gitdiff);
-    string CreateCustomCommitPrompt(string gitdiff);
+    string CreateCommitPrompt(PromptType promptType, string stagedChanges);
 }

--- a/Ghost.Common/Services/IMessageFormatter.cs
+++ b/Ghost.Common/Services/IMessageFormatter.cs
@@ -1,0 +1,6 @@
+﻿namespace Ghost.Common.Services;
+
+public interface IMessageFormatter
+{
+    List<string> Format(string messages, string? code = null);
+}

--- a/Ghost.Infrastructure/Factories/MessageFormatterFactory.cs
+++ b/Ghost.Infrastructure/Factories/MessageFormatterFactory.cs
@@ -1,0 +1,19 @@
+﻿using Ghost.Common.Services;
+using Ghost.Infrastructure.Models.Enum;
+using Ghost.Infrastructure.Services;
+
+namespace Ghost.Infrastructure.Factories;
+
+public static class MessageFormatterFactory
+{
+    public static IMessageFormatter GetFormatter(PromptType promptType)
+    {
+        return promptType switch
+        {
+            PromptType.StartingWithCode => new StartingWithCodeFormatter(),
+            PromptType.Custom => new CustomFormatter(),
+            PromptType.Conventional => new ConventionalFormatter(),
+            _ => throw new ArgumentException("Invalid prompt type")
+        };
+    }
+}

--- a/Ghost.Infrastructure/Factories/PromptFactory.cs
+++ b/Ghost.Infrastructure/Factories/PromptFactory.cs
@@ -1,5 +1,4 @@
-﻿using Ghost.Infrastructure.Factories;
-using Ghost.Infrastructure.Models;
+﻿using Ghost.Infrastructure.Models;
 using Ghost.Infrastructure.Models.Enum;
 using Ghost.Infrastructure.Repositories;
 using System.Text;
@@ -15,32 +14,20 @@ public class PromptFactory : IPromptFactory
         _repository = repository;
     }
 
-    public string CreateConventionalCommitPrompt(string stagedChanges)
+    public string CreateCommitPrompt(PromptType promptType, string stagedChanges)
     {
-        var template = _repository.GetPromptByName(PromptType.Conventional);
+        var template = _repository.GetPromptByName(promptType);
         return BuildPrompt(template, stagedChanges);
     }
 
-    public string CreateCommitStartingWithCodePrompt(string stagedChanges, string code)
-    {
-        var template = _repository.GetPromptByName(PromptType.StartingWithCode);
-        return BuildPrompt(template, stagedChanges, code);
-    }
-
-    public string CreateCustomCommitPrompt(string stagedChanges)
-    {
-        var template = _repository.GetPromptByName(PromptType.Custom);
-        return BuildPrompt(template, stagedChanges);
-    }
-
-    private string BuildPrompt(Prompt prompt, string stagedChanges, string? code = null)
+    private string BuildPrompt(Prompt prompt, string stagedChanges)
     {
         var builder = new StringBuilder();
 
         var actions = new List<Action>
         {
             () => builder.AppendLine(prompt.Introduction.Replace("{stagedChanges}", stagedChanges)),
-            () => AddFormat(builder, prompt.Format, code),
+            () => AddFormat(builder, prompt.Format),
             () => AddSection(builder, "Types:", prompt.Types!),
             () => AddSection(builder, "Specification:", prompt.Specification),
             () => builder.AppendLine(prompt.Footer)
@@ -51,10 +38,10 @@ public class PromptFactory : IPromptFactory
         return builder.ToString();
     }
 
-    private void AddFormat(StringBuilder builder, string format, string? code)
+    private void AddFormat(StringBuilder builder, string format)
     {
         if (!string.IsNullOrWhiteSpace(format))
-            builder.AppendLine(!string.IsNullOrWhiteSpace(code) ? format.Replace("{code}", code) : format);
+            builder.AppendLine(format);
     }
 
     private void AddSection(StringBuilder builder, string sectionTitle, List<string> sectionItems)

--- a/Ghost.Infrastructure/Services/GitService.cs
+++ b/Ghost.Infrastructure/Services/GitService.cs
@@ -1,6 +1,5 @@
 ﻿using CliWrap.Exceptions;
 using CliWrap;
-using Ghost.Infrastructure.Services;
 using CliWrap.Buffered;
 
 namespace Ghost.Infrastructure.Services;

--- a/Ghost.Infrastructure/Services/MessageFormatter.cs
+++ b/Ghost.Infrastructure/Services/MessageFormatter.cs
@@ -1,0 +1,23 @@
+﻿using Ghost.Common.Services;
+using Ghost.Infrastructure.Utilities.Extensions;
+
+namespace Ghost.Infrastructure.Services;
+
+public class StartingWithCodeFormatter : IMessageFormatter
+{
+    public List<string> Format(string messages, string? code = null) 
+        => messages.Separate().AddPrefix(code!);
+}
+
+public class CustomFormatter : IMessageFormatter
+{
+    public List<string> Format(string messages, string? code = null) 
+        => messages.Separate();
+}
+
+public class ConventionalFormatter : IMessageFormatter
+{
+    public List<string> Format(string messages, string? code = null) 
+        => messages.Separate();
+}
+

--- a/Ghost.Infrastructure/Utilities/Extensions/StringExtensions.cs
+++ b/Ghost.Infrastructure/Utilities/Extensions/StringExtensions.cs
@@ -1,0 +1,16 @@
+﻿namespace Ghost.Infrastructure.Utilities.Extensions;
+
+public static class StringExtensions
+{
+    public static List<string> Separate(this string messages)
+    {
+        return messages.Split('|')
+                       .Select(message => message.Trim().ToLower())
+                       .ToList();
+    }
+    public static List<string> AddPrefix(this IEnumerable<string> messages, string prefix)
+    {
+        return messages.Select(message => $"{prefix} - {message}")
+                       .ToList();
+    }
+}

--- a/Ghost.Infrastructure/Utilities/FileManager.cs
+++ b/Ghost.Infrastructure/Utilities/FileManager.cs
@@ -1,8 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Options;
-using System.IO;
-
-namespace Ghost.Infrastructure.Utilities;
+﻿namespace Ghost.Infrastructure.Utilities;
 
 public static class FileManager
 {

--- a/Ghost.Runner/appsettings.json
+++ b/Ghost.Runner/appsettings.json
@@ -5,16 +5,16 @@
   "PromptType": {
     "StartingWithCode": {
       "Introduction": "You're an automated AI that generates three git commit messages synthesizing the following diff changes: {stagedChanges}.",
-      "Format": "The commit MUST follow this format:\"{code} - <description> \"",
+      "Format": "The commit MUST follow this format:\"<description> \"",
       "Specification": [
-        "EVERY commit must start with the provided code, even its two or more words.",
-        "The first letter after the code MUST be lowercase.",
-        "Every commit MUST start with '{code} - '.",
-        "The description must be clear and concise.",
-        "Descriptions MUST be as descriptive as possible within 50 characters.",
+        "The description must be clear, concise, and descriptive.",
+        "Descriptions MUST be as descriptive as possible, providing sufficient detail about the changes made.",
+        "Descriptions MUST synthesize all changes into a single cohesive message, even if multiple changes are present.",
         "MUST NOT have body and footer.",
         "Do NOT include the contents of the git diff in the response.",
-        "you MUST Provide three commit message options separated by commas."
+        "Descriptions MUST contain only words without any special characters like ':', '()', etc.",
+        "You MUST provide three commit message options separated by the pipe '|' character.",
+        "For example, correct messages would be: 'fix bug in login', 'add new validation rule', 'update dependencies'."
       ],
       "Footer": "Exclude anything unnecessary, because your entire response will be passed directly into git commit"
     },
@@ -36,7 +36,6 @@
         "Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc., followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.",
         "A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., fix(parser):",
         "A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.",
-        "A description MUST start with lowercase.",
         "MUST NOT have body and footer.",
         "Descriptions MUST be as descriptive as possible within 50 characters.",
         "Descriptions CANNOT use past tense verbs.",
@@ -45,7 +44,7 @@
         "Types other than feat and fix MAY be used in your commit messages, e.g., docs: update ref docs.",
         "The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.",
         "Do NOT include the contents of the git diff in the response.",
-        "you MUST Provide three commit message options separated by commas."
+        "You MUST provide three commit message options separated by the pipe '|' character."
       ],
       "Footer": "Exclude anything unnecessary, because your entire response will be passed directly into git commit"
     },


### PR DESCRIPTION
### Fixes
- Ensures that the commit messages generated with the "StartingWithCode" template include the full and correct code prefix by concatenating the code as a prefix in the `CodePrefixCommitMessageTransformer`.
